### PR TITLE
Fix adb command so it is all on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ On Android Studio, click on the "Run" button.
 If you prefer to run on the command line, type
 ```bash
 ./gradlew installDebug
-adb shell am start
-com.example.androidthings.imageclassifier/.ImageClassifierActivity
+adb shell am start com.example.androidthings.imageclassifier/.ImageClassifierActivity
 ```
 
 If you have everything set up correctly:


### PR DESCRIPTION
The extra line break means the command can't be copy and pasted as easily.

As mentioned in this issue: https://github.com/androidthings/sample-tensorflow-imageclassifier/issues/9

TESTING

Tested on Mac OSX using an emulator.